### PR TITLE
safe crate access + configurable MACRO_MAGIC_ROOT

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+MACRO_MAGIC_ROOT = "::macro_magic"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,8 +7,6 @@ repository = "https://github.com/sam0x17/macro_magic"
 homepage = "https://sam0x17.dev"
 license = "MIT"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/tests/test_macros/src/lib.rs
+++ b/tests/test_macros/src/lib.rs
@@ -20,8 +20,9 @@ use syn::{parse_macro_input, spanned::Spanned, Error, Fields, Item, ItemMod, Ite
 pub fn include_impl(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     let external_path = parse_macro_input!(attr as Path);
     let _item_mod = parse_macro_input!(tokens as ItemMod);
+    let mm_path = macro_magic::core::macro_magic_root();
     quote! {
-        ::macro_magic::forward_tokens! { #external_path, include_impl_inner }
+        #mm_path::forward_tokens! { #external_path, include_impl_inner }
     }
     .into()
 }


### PR DESCRIPTION
* adds configurable MACRO_MAGIC_ROOT env var and methods for safe crate
* can now create a `.cargo/config.toml` in your project and specify an `[env]` section containing an override for `MACRO_MAGIC_ROOT`
* macro_magic will use this override everywhere instead of the default which is ::macro_magic
* this allows you to use a re-exported macro_magic if you have an exotic project structure