### PR TITLE
Avoid discarding error when failing to parse a path

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -689,9 +689,11 @@ pub fn import_tokens_attr_internal<T1: Into<TokenStream2>, T2: Into<TokenStream2
     attr: T1,
     tokens: T2,
 ) -> Result<TokenStream2> {
-    let mm_override_path = match parse2::<Path>(attr.into()) {
-        Ok(override_path) => override_path,
-        Err(_) => macro_magic_root(),
+    let attr = attr.into();
+    let mm_override_path = if attr.is_empty() {
+        macro_magic_root()
+    } else {
+        parse2::<Path>(attr)?
     };
     let mm_path = macro_magic_root();
     let mut proc_macro = parse_proc_macro_variant(tokens, ProcMacroType::Attribute)?;
@@ -797,9 +799,11 @@ pub fn import_tokens_proc_internal<T1: Into<TokenStream2>, T2: Into<TokenStream2
     attr: T1,
     tokens: T2,
 ) -> Result<TokenStream2> {
-    let mm_override_path = match parse2::<Path>(attr.into()) {
-        Ok(override_path) => override_path,
-        Err(_) => macro_magic_root(),
+    let attr = attr.into();
+    let mm_override_path = if attr.is_empty() {
+        macro_magic_root()
+    } else {
+        parse2::<Path>(attr)?
     };
     let mm_path = macro_magic_root();
     let proc_macro = parse_proc_macro_variant(tokens, ProcMacroType::Normal)?;


### PR DESCRIPTION
If I make a mistake in the path in the argument of `import_token_attr` like this:
```diff
diff --git a/tests/test_macros/src/lib.rs b/tests/test_macros/src/lib.rs
index cacd071..faebae8 100644
--- a/tests/test_macros/src/lib.rs
+++ b/tests/test_macros/src/lib.rs
@@ -58,7 +58,7 @@ pub fn some_other_macro(tokens: TokenStream) -> TokenStream {
     .into()
 }
 
-#[import_tokens_attr(middle_crate::export_mod::sub_mod::macro_magic)]
+#[import_tokens_attr(middle_crate:export_mod::sub_mod::macro_magic)]
 #[proc_macro_attribute]
 pub fn distant_re_export_attr(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     let imported_item = parse_macro_input!(attr as Item);
```
then the attribute is simply discarded without warning or error.
Having the attribute ignore is confusing and people can wonder why macro_magic is not found at the path they are expected because they made a typo in the path.