### PR TITLE
New export_tokens path strategy

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 //! This crate contains most of the internal implementation of the macros in the
 //! `macro_magic_macros` crate. For the most part, the proc macros in `macro_magic_macros` just
 //! call their respective `_internal` variants in this crate.
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use derive_syn_parse::Parse;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,10 +1,7 @@
 //! This crate contains most of the internal implementation of the macros in the
 //! `macro_magic_macros` crate. For the most part, the proc macros in `macro_magic_macros` just
 //! call their respective `_internal` variants in this crate.
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use derive_syn_parse::Parse;
 use macro_magic_core_macros::*;

--- a/tests/external_crate/src/lib.rs
+++ b/tests/external_crate/src/lib.rs
@@ -2,7 +2,7 @@
 
 use macro_magic::*;
 
-mod some_submodule {
+pub mod some_submodule {
     use macro_magic::*;
 
     struct FooBarStruct {}
@@ -38,13 +38,6 @@ fn an_external_function(my_num: u32) -> u32 {
 mod an_external_module {
     fn my_cool_function() -> u32 {
         567
-    }
-}
-
-fn _some_function() {
-    #[export_tokens]
-    fn some_sub_function() -> u32 {
-        33
     }
 }
 

--- a/tests/middle_crate/src/lib.rs
+++ b/tests/middle_crate/src/lib.rs
@@ -8,7 +8,4 @@ pub mod export_mod {
 struct ForeignItem {}
 
 pub use test_macros::distant_re_export_attr;
-
 pub use test_macros::distant_re_export_proc;
-
-pub use macro_magic::{use_attr, use_proc};

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -86,7 +86,7 @@ pub mod hunter {
     }
 }
 
-#[test_tokens_attr2(external_crate::AnExternalTraitImpl)]
+#[test_tokens_attr2(external_crate::some_submodule::AnExternalTraitImpl)]
 struct LocalItemStruct {}
 
 #[test_tokens_attr_direct_import(external_crate::an_external_function)]
@@ -101,7 +101,7 @@ struct LionStruct {}
 struct TigerStruct {}
 
 // test proc item position
-item_level_proc!(external_crate::AnExternalTraitImpl);
+item_level_proc!(external_crate::some_submodule::AnExternalTraitImpl);
 
 #[test]
 fn test_import_tokens_proc_item_position() {
@@ -111,23 +111,14 @@ fn test_import_tokens_proc_item_position() {
 #[test]
 fn test_import_tokens_proc_statement_position() {
     example_tokens_proc!(LionStruct);
-    example_tokens_proc!(external_crate::AnExternalTraitImpl);
+    example_tokens_proc!(external_crate::some_submodule::AnExternalTraitImpl);
 }
 
 #[test]
 fn test_import_tokens_proc_expr_position() {
     let something = example_tokens_proc!(TigerStruct);
     assert_eq!(something.to_string(), "struct TigerStruct {}");
-    let _something_else = example_tokens_proc!(external_crate::AnExternalTraitImpl);
-}
-
-#[test]
-fn test_export_tokens_inside_function() {
-    let something = example_tokens_proc!(external_crate::some_sub_function);
-    assert_eq!(
-        something.to_string(),
-        "fn some_sub_function() -> u32 { 33 }"
-    );
+    let _something_else = example_tokens_proc!(external_crate::some_submodule::AnExternalTraitImpl);
 }
 
 #[test]
@@ -166,7 +157,7 @@ fn import_tokens_same_mod_ident() {
 #[cfg(feature = "proc_support")]
 #[test]
 fn import_tokens_different_mod_no_ident() {
-    import_tokens!(let tokens = PlusPlus);
+    import_tokens!(let tokens = some_module::PlusPlus);
     assert_eq!(
         tokens.to_string(),
         "fn plus_plus < T : Into < i64 > > (n : T) -> i64 { n . into () + 1 }"
@@ -176,7 +167,7 @@ fn import_tokens_different_mod_no_ident() {
 #[cfg(feature = "proc_support")]
 #[test]
 fn import_tokens_different_mod_ident() {
-    import_tokens!(let tokens = MinusMinus);
+    import_tokens!(let tokens = some_module::MinusMinus);
     assert_eq!(
         tokens.to_string(),
         "fn minus_minus < T : Into < i32 > > (n : T) -> i32 { n . into () - 1 }"
@@ -199,7 +190,7 @@ fn println_inside_fn_current_file() {
 
 #[test]
 fn println_inside_fn_external_file() {
-    let tokens = example_tokens_proc!(external_fn_with_println);
+    let tokens = example_tokens_proc!(external_file::external_fn_with_println);
     assert_eq!(
         tokens.to_string(),
         "fn external_fn_with_println() { println! (\"testing\") ; }"


### PR DESCRIPTION
This fulfills item 2 from #3 

With this new strategy, we can now properly access `#[export_tokens]` declarations as real items within the modules in which they are defined, instead of faking it and accessing them from the #[macro_export] created at the crate root.

This is a breaking change since it is no longer possible (at least with how the macros are written currently) to do two things that used to be possible:
1. access `#[export_tokens]` declarations that are _inside of_ things like functions that are not accessible at the module level
2. access `#[export_tokens]` declarations that are in private modules

I think this is largely OK if we have to drop support for this, but I would still like to brainstorm some possible workarounds so we can still make these work, possibly with some additional opt-in macro argument.