### PR TITLE
Allow Path or Expr evaluating to Into<String> as arg for import_tokens_proc and import_tokens_attr

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -749,7 +749,7 @@ impl syn::parse::Parse for OverridePath {
             Ok(expr) => Ok(OverridePath::Expr(expr)),
             Err(mut err) => {
                 err.combine(Error::new(
-                    input.span(), 
+                    input.span(),
                     "Expected either a `Path` or an `Expr` that evaluates to something compatible with `Into<String>`."
                 ));
                 Err(err)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -745,7 +745,16 @@ impl syn::parse::Parse for OverridePath {
         if let Ok(path) = parse2::<Path>(remaining.clone()) {
             return Ok(OverridePath::Path(path));
         }
-        Ok(OverridePath::Expr(parse2::<Expr>(remaining)?))
+        match parse2::<Expr>(remaining) {
+            Ok(expr) => Ok(OverridePath::Expr(expr)),
+            Err(mut err) => {
+                err.combine(Error::new(
+                    input.span(), 
+                    "Expected either a `Path` or an `Expr` that evaluates to something compatible with `Into<String>`."
+                ));
+                Err(err)
+            }
+        }
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -113,8 +113,8 @@ pub struct AttrItemWithExtra {
     #[brace]
     #[inside(_brace)]
     _tokens_ident_brace: Brace,
-    /// A [`TokenStream2`] representing the raw tokens for the [`Ident`] the generated macro
-    /// will use to refer to the tokens argument of the macro.
+    /// A [`TokenStream2`] representing the raw tokens for the [`struct@Ident`] the generated
+    /// macro will use to refer to the tokens argument of the macro.
     #[inside(_tokens_ident_brace)]
     pub tokens_ident: TokenStream2,
     #[inside(_brace)]
@@ -145,7 +145,7 @@ pub struct AttrItemWithExtra {
 #[derive(Parse)]
 pub struct ImportTokensArgs {
     _let: Token![let],
-    /// The [`Ident`] for the `tokens` variable. Usually called [`tokens`] but could be
+    /// The [`struct@Ident`] for the `tokens` variable. Usually called `tokens` but could be
     /// something different, hence this variable.
     pub tokens_var_ident: Ident,
     _eq: Token![=],
@@ -158,7 +158,7 @@ pub struct ImportTokensArgs {
 /// You shouldn't need to use this directly.
 #[derive(Parse)]
 pub struct ImportedTokens {
-    /// Represents the [`Ident`] that was used to refer to the `tokens` in the original
+    /// Represents the [`struct@Ident`] that was used to refer to the `tokens` in the original
     /// [`ImportTokensArgs`].
     pub tokens_var_ident: Ident,
     _comma: Comma,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -854,7 +854,10 @@ pub fn import_tokens_attr_internal<T1: Into<TokenStream2>, T2: Into<TokenStream2
                 #path_resolver
                 let path = path.to_token_stream();
                 let custom_parsed = custom_parsed.to_token_stream();
-                let resolved_mm_override_path = syn::parse2::<syn::Path>(String::from(#mm_override_path).parse().unwrap()).unwrap();
+                let resolved_mm_override_path = match syn::parse2::<syn::Path>(String::from(#mm_override_path).parse().unwrap()) {
+                    Ok(res) => res,
+                    Err(err) => return err.to_compile_error().into()
+                };
                 quote::quote! {
                     #pound resolved_mm_override_path::forward_tokens! {
                         #pound path,
@@ -936,7 +939,10 @@ pub fn import_tokens_proc_internal<T1: Into<TokenStream2>, T2: Into<TokenStream2
                     Ok(path) => path,
                     Err(e) => return e.to_compile_error().into(),
                 };
-                let resolved_mm_override_path = syn::parse2::<syn::Path>(String::from(#mm_override_path).parse().unwrap()).unwrap();
+                let resolved_mm_override_path = match syn::parse2::<syn::Path>(String::from(#mm_override_path).parse().unwrap()) {
+                    Ok(res) => res,
+                    Err(err) => return err.to_compile_error().into()
+                };
                 quote::quote! {
                     #pound resolved_mm_override_path::forward_tokens! {
                         #pound source_path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,17 +43,28 @@
 //!
 //! One thing that `macro_magic` _doesn't_ provide is the ability to build up state information
 //! across multiple macro invocations, however this problem can be tackled effectively using
-//! the [outer macro pattern](https://www.youtube.com/watch?v=aEWbZxNCH0A). There is also my
-//! (deprecated but functional) [macro_state](https://crates.io/crates/macro_state) crate,
-//! which relies on some incidental features of the rust compiler that could be removed in the
-//! future.
+//! the [outer macro pattern](https://www.youtube.com/watch?v=aEWbZxNCH0A) or in some cases
+//! using static atomics and mutexes in your proc macro crate (which we actually do in this
+//! crate to keep track of unique identifiers).
 //!
-//! Note that the transition from 0.1.7 to 0.2.0 of `macro_magic` removed and/or re-wrote a
-//! number of features that relied on a non-future-proof behavior of writing/reading files from
-//! the `OUT_DIR`. Versions of `macro_magic` >= 0.2.0 are completely future-proof and safe,
-//! however features that provided the ability to enumerate all the `#[export_tokens]` calls in
-//! a namespace have been removed. The proper way to do this is with the outer macro pattern,
-//! mentioned above.
+//! ## Breaking Changes
+//!
+//! - **0.4x** removed `#[use_attr]` and `#[use_proc]` (they are no longer needed with the new
+//!   self-calling macro style that has been adopted in 0.4x) and also removed the ability to
+//!   access `#[export_tokens]` invocations in inaccessible locations like inside of functions
+//!   and across module permission boundaries like in an inaccessible private module. This
+//!   feature may be re-added in the future if there is interest, however removing it allowed
+//!   us to consolidate naming of our `macro_rules!` declarations and remove the need for
+//!  `#[use_attr]` / `#[use_proc]`.
+//! - **0.2x** removed and/or re-wrote a number of features that relied on a non-future-proof
+//!   behavior of writing/reading files in the `OUT_DIR`. Versions >= 0.2.0 are completely safe
+//!   and no longer contain this behavior, however features that provided the ability to
+//!   enumerate all the `#[export_tokens]` calls in a namespace have been removed. The proper
+//!   way to do this is with the outer macro pattern or with global state mutexes/atomics in
+//!   your proc macro crate, as mentioned above.
+//!
+//! More detailed historical change information can be found in
+//! [releases](https://github.com/sam0x17/docify/releases).
 
 #![no_std]
 

--- a/tests/test_macros/src/lib.rs
+++ b/tests/test_macros/src/lib.rs
@@ -70,7 +70,9 @@ pub fn some_other_macro(tokens: TokenStream) -> TokenStream {
     .into()
 }
 
-#[import_tokens_attr(middle_crate::export_mod::sub_mod::macro_magic)]
+// as demonstrated here, `import_tokens_attr` can take a path or an expression that evaluates
+// to something compatible with `Into<String>`
+#[import_tokens_attr(format!("{}::export_mod::sub_mod::macro_magic", "middle_crate"))]
 #[proc_macro_attribute]
 pub fn distant_re_export_attr(attr: TokenStream, tokens: TokenStream) -> TokenStream {
     let imported_item = parse_macro_input!(attr as Item);

--- a/tests/test_macros/src/lib.rs
+++ b/tests/test_macros/src/lib.rs
@@ -87,7 +87,7 @@ pub fn distant_re_export_attr(attr: TokenStream, tokens: TokenStream) -> TokenSt
     .into()
 }
 
-#[import_tokens_proc(middle_crate::export_mod::sub_mod::macro_magic)]
+#[import_tokens_proc(format!("middle_crate::export_mod::{}::macro_magic", "sub_mod"))]
 #[proc_macro]
 pub fn distant_re_export_proc(tokens: TokenStream) -> TokenStream {
     let imported_item = parse_macro_input!(tokens as Item);


### PR DESCRIPTION
Part of #3, specifically closes item 3 of it

Originally just Path was supported. This adds additional support for an expression that evaluates to something compatible to `Into<String>`. This is useful for the scenario outlined in #3 where we might have to determine at compile-time what the real path to macro_magic is from the perspective of the user of your proc macro.