### PR TITLE
upgrade derive-syn-parse

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,7 @@ all-features = true
 [dependencies]
 quote = "1"
 syn = { version = "2", features = ["full"] }
-derive-syn-parse = "0.1.5"
+derive-syn-parse = "0.2.0"
 proc-macro2 = "1"
 macro_magic_core_macros = { version = "0.5.0", path = "../core_macros" }
 const-random = "0.1.15"

--- a/tests/test_macros/Cargo.toml
+++ b/tests/test_macros/Cargo.toml
@@ -10,6 +10,6 @@ proc-macro = true
 [dependencies]
 macro_magic = { path = "../../", features = ["proc_support"] }
 syn = { version = "2", features = ["full"] }
-quote.workspace = "1"
+quote = "1"
 proc-macro2 = "1"
 derive-syn-parse = "0.2.0"

--- a/tests/test_macros/Cargo.toml
+++ b/tests/test_macros/Cargo.toml
@@ -10,6 +10,6 @@ proc-macro = true
 [dependencies]
 macro_magic = { path = "../../", features = ["proc_support"] }
 syn = { version = "2", features = ["full"] }
-quote = "1"
+quote.workspace = "1"
 proc-macro2 = "1"
-derive-syn-parse = "0.1.5"
+derive-syn-parse = "0.2.0"

--- a/tests/test_macros/src/lib.rs
+++ b/tests/test_macros/src/lib.rs
@@ -105,7 +105,7 @@ pub fn test_tokens_attr1(attr: TokenStream, tokens: TokenStream) -> TokenStream 
     assert_eq!(imported_item_str, "struct AnotherStruct { field1 : u32, }");
     assert_eq!(
         attached_item_str,
-        "pub mod hunter { pub fn stuff() { println! (\"things\") ; } }"
+        "pub mod hunter { pub fn stuff() { println! (\"things\"); } }"
     );
     quote! {
         #attached_item

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -184,7 +184,7 @@ fn println_inside_fn_current_file() {
     let tokens = example_tokens_proc!(a_random_fn);
     assert_eq!(
         tokens.to_string(),
-        "fn a_random_fn() { println! (\"hey\") ; }"
+        "fn a_random_fn() { println! (\"hey\"); }"
     );
 }
 
@@ -193,7 +193,7 @@ fn println_inside_fn_external_file() {
     let tokens = example_tokens_proc!(external_file::external_fn_with_println);
     assert_eq!(
         tokens.to_string(),
-        "fn external_fn_with_println() { println! (\"testing\") ; }"
+        "fn external_fn_with_println() { println! (\"testing\"); }"
     );
 }
 
@@ -202,7 +202,7 @@ fn macro_calls_inside_fn_external_crate() {
     let tokens = example_tokens_proc!(external_crate::external_fn_with_local_macro_calls);
     assert_eq!(
         tokens.to_string(),
-        "fn external_fn_with_local_macro_calls() -> u32 { another_macro! () ; 1337 }"
+        "fn external_fn_with_local_macro_calls() -> u32 { another_macro! (); 1337 }"
     );
 }
 


### PR DESCRIPTION
This makes the crate not rely on `syn` version 1

<details><summary>Details</summary>
<p>

Before this change:
```
[16:18:37] Φ cargo tree                                                
macro_magic v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic)
└── macro_magic_macros v0.5.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/macros)
    ├── macro_magic_core v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic/core)
    │   ├── const-random v0.1.18
    │   │   └── const-random-macro v0.1.16 (proc-macro)
    │   │       ├── getrandom v0.2.15
    │   │       │   ├── cfg-if v1.0.0
    │   │       │   └── libc v0.2.155
    │   │       ├── once_cell v1.19.0
    │   │       └── tiny-keccak v2.0.2
    │   │           └── crunchy v0.2.2
    │   ├── derive-syn-parse v0.1.5 (proc-macro)
    │   │   ├── proc-macro2 v1.0.86
    │   │   │   └── unicode-ident v1.0.12
    │   │   ├── quote v1.0.36
    │   │   │   └── proc-macro2 v1.0.86 (*)
    │   │   └── syn v1.0.109 <------------------------------- here
    │   │       ├── proc-macro2 v1.0.86 (*)
    │   │       ├── quote v1.0.36 (*)
    │   │       └── unicode-ident v1.0.12
    │   ├── macro_magic_core_macros v0.5.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/core_macros)
    │   │   ├── proc-macro2 v1.0.86 (*)
    │   │   ├── quote v1.0.36 (*)
    │   │   └── syn v2.0.68
    │   │       ├── proc-macro2 v1.0.86 (*)
    │   │       ├── quote v1.0.36 (*)
    │   │       └── unicode-ident v1.0.12
    │   ├── proc-macro2 v1.0.86 (*)
    │   ├── quote v1.0.36 (*)
    │   └── syn v2.0.68 (*)
    ├── quote v1.0.36 (*)
    └── syn v2.0.68 (*)
[dev-dependencies]
├── external_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/external_crate)
│   └── macro_magic v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic) (*)
├── isolated_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/isolated_crate)
│   └── middle_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/middle_crate)
│       ├── macro_magic v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic) (*)
│       └── test_macros v0.1.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/tests/test_macros)
│           ├── derive-syn-parse v0.1.5 (proc-macro) (*)
│           ├── macro_magic v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic)
│           │   ├── macro_magic_core v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic/core) (*)
│           │   ├── macro_magic_macros v0.5.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/macros) (*)
│           │   ├── quote v1.0.36 (*)
│           │   └── syn v2.0.68 (*)
│           │   [dev-dependencies]
│           │   ├── external_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/external_crate) (*)
│           │   ├── isolated_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/isolated_crate) (*)
│           │   ├── middle_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/middle_crate) (*)
│           │   └── test_macros v0.1.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/tests/test_macros) (*)
│           ├── proc-macro2 v1.0.86 (*)
│           ├── quote v1.0.36 (*)
│           └── syn v2.0.68 (*)
├── middle_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/middle_crate) (*)
└── test_macros v0.1.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/tests/test_macros) (*)
```

After
```
cargo tree
macro_magic v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic)
└── macro_magic_macros v0.5.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/macros)
    ├── macro_magic_core v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic/core)
    │   ├── const-random v0.1.18
    │   │   └── const-random-macro v0.1.16 (proc-macro)
    │   │       ├── getrandom v0.2.15
    │   │       │   ├── cfg-if v1.0.0
    │   │       │   └── libc v0.2.155
    │   │       ├── once_cell v1.19.0
    │   │       └── tiny-keccak v2.0.2
    │   │           └── crunchy v0.2.2
    │   ├── derive-syn-parse v0.2.0 (proc-macro)
    │   │   ├── proc-macro2 v1.0.86
    │   │   │   └── unicode-ident v1.0.12
    │   │   ├── quote v1.0.36
    │   │   │   └── proc-macro2 v1.0.86 (*)
    │   │   └── syn v2.0.68
    │   │       ├── proc-macro2 v1.0.86 (*)
    │   │       ├── quote v1.0.36 (*)
    │   │       └── unicode-ident v1.0.12
    │   ├── macro_magic_core_macros v0.5.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/core_macros)
    │   │   ├── proc-macro2 v1.0.86 (*)
    │   │   ├── quote v1.0.36 (*)
    │   │   └── syn v2.0.68 (*)
    │   ├── proc-macro2 v1.0.86 (*)
    │   ├── quote v1.0.36 (*)
    │   └── syn v2.0.68 (*)
    ├── quote v1.0.36 (*)
    └── syn v2.0.68 (*)
[dev-dependencies]
├── external_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/external_crate)
│   └── macro_magic v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic) (*)
├── isolated_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/isolated_crate)
│   └── middle_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/middle_crate)
│       ├── macro_magic v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic) (*)
│       └── test_macros v0.1.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/tests/test_macros)
│           ├── derive-syn-parse v0.2.0 (proc-macro) (*)
│           ├── macro_magic v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic)
│           │   ├── macro_magic_core v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic/core) (*)
│           │   ├── macro_magic_macros v0.5.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/macros) (*)
│           │   ├── quote v1.0.36 (*)
│           │   └── syn v2.0.68 (*)
│           │   [dev-dependencies]
│           │   ├── external_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/external_crate) (*)
│           │   ├── isolated_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/isolated_crate) (*)
│           │   ├── middle_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/middle_crate) (*)
│           │   └── test_macros v0.1.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/tests/test_macros) (*)
│           ├── proc-macro2 v1.0.86 (*)
│           ├── quote v1.0.36 (*)
│           └── syn v2.0.68 (*)
├── middle_crate v0.1.0 (/Users/jmgd/Documents/Eiger/macro_magic/tests/middle_crate) (*)
└── test_macros v0.1.0 (proc-macro) (/Users/jmgd/Documents/Eiger/macro_magic/tests/test_macros) (*)

macro_magic v0.5.0 (/Users/jmgd/Documents/Eiger/macro_magic) (*)
```



</p>
</details> 
